### PR TITLE
Don't export library PROJECT_NAME which doesn't exist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ generate_messages(DEPENDENCIES std_msgs geometry_msgs)
 
 #add catkin sourced packages:
 catkin_package(
+   LIBRARIES door_plugin elevator auto_door
    CATKIN_DEPENDS roscpp nodelet std_msgs geometry_msgs tf gazebo_plugins gazebo_ros message_runtime
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ generate_messages(DEPENDENCIES std_msgs geometry_msgs)
 
 #add catkin sourced packages:
 catkin_package(
-   LIBRARIES ${PROJECT_NAME}
    CATKIN_DEPENDS roscpp nodelet std_msgs geometry_msgs tf gazebo_plugins gazebo_ros message_runtime
 )
 


### PR DESCRIPTION
dynamic_gazebo_models is exporting $PROJECT_NAME as a library in the catkin package.  The problem is that there is no library created and installed named $PROJECT_NAME.

This has not caused any problems in the normal catkin build as it's just not there.  The problem has arose in the ros1bridge compilation using our SDK and converting ros messages from ros1 to ros2.  The ROS tool used uses the package configuration and fails when it can't find the dynamic_gazebo_models library.

This issue was discussed upstream with the ros1bridge/ROS2 maintainers and the fix is to fix dynamic_gazebo_models.
For reference https://github.com/ros2/ros1_bridge/issues/88
