### PR TITLE
TOOL-3121: remove .py from xacro script name

### DIFF
--- a/launch/door.launch
+++ b/launch/door.launch
@@ -17,7 +17,7 @@
 
   <env name="GAZEBO_MODEL_PATH" value="$(find dynamic_gazebo_models)/models:$(optenv GAZEBO_MODEL_PATH)"/>
 
-  <param name="$(arg name)" command="$(find xacro)/xacro.py '$(find dynamic_gazebo_models)/models/door.sdf.xacro' name:='$(arg name)' size:='$(arg size)' type:='$(arg type)' direction:='$(arg direction)' color:='$(arg color)' axis:='$(arg axis)' effort:='$(arg effort)' velocity:='$(arg velocity)' max_trans_dist:='$(arg max_trans_dist)'"/>
+  <param name="$(arg name)" command="$(find xacro)/xacro '$(find dynamic_gazebo_models)/models/door.sdf.xacro' name:='$(arg name)' size:='$(arg size)' type:='$(arg type)' direction:='$(arg direction)' color:='$(arg color)' axis:='$(arg axis)' effort:='$(arg effort)' velocity:='$(arg velocity)' max_trans_dist:='$(arg max_trans_dist)'"/>
 
   <node pkg="gazebo_ros" type="spawn_model" name="$(anon spawn_door)"
         args="-sdf -param $(arg name) -model $(arg name) $(arg gzpose)"

--- a/launch/dynamic_models_test.launch
+++ b/launch/dynamic_models_test.launch
@@ -18,40 +18,40 @@
 
   <!-- Flip Door Left -->
 
-  <param name="spawn_door_1" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/flip_door_right.sdf" />
+  <param name="spawn_door_1" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/flip_door_right.sdf" />
 
   <node pkg="gazebo_ros" type="spawn_model" name="gazebo_door1" args="-sdf -param spawn_door_1 -model door_1 -x -3.042358 -y 5.532777 -z 0.3" respawn="false" output="screen">
   </node>
 
   <!-- Flip Door Right -->
 
-  <param name="spawn_door_2" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/flip_door_left.sdf" />
+  <param name="spawn_door_2" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/flip_door_left.sdf" />
 
   <node pkg="gazebo_ros" type="spawn_model" name="gazebo_door2" args="-sdf -param spawn_door_2 -model door_2 -x -4.452335 -y 5.078486 -z 0.3" respawn="false" output="screen">
   </node>
 
   <!-- Slide Door Right -->
 
-  <param name="spawn_door_3" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/slide_right.sdf" />
+  <param name="spawn_door_3" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/slide_right.sdf" />
 
   <node pkg="gazebo_ros" type="spawn_model" name="gazebo_door3" args="-sdf -param spawn_door_3 -model door_3 -x -5.728697 -y -13.045468 -z 0.3" respawn="false" output="screen">
   </node>
 
   <!-- Slide Door Left -->
 
-  <param name="spawn_door_4" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/slide_left.sdf" />
+  <param name="spawn_door_4" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/slide_left.sdf" />
 
   <node pkg="gazebo_ros" type="spawn_model" name="gazebo_door4" args="-sdf -param spawn_door_4 -model door_4 -x -5.728697 -y -12.232026 -z 0.3" respawn="false" output="screen">
   </node>
 
   <!-- Elevator 1 -->
-  <param name="spawn_elevator_1" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elevator.sdf" />
+  <param name="spawn_elevator_1" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elevator.sdf" />
 
   <node pkg="gazebo_ros" type="spawn_model" name="gazebo_elevator1" args="-sdf -param spawn_elevator_1 -model elevator_1 -x 9.402078 -y 16.611233 -z 0.3" respawn="false" output="screen">
   </node>
 
   <!-- Elevator 2 -->
-  <param name="spawn_elevator_2" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elevator.sdf" />
+  <param name="spawn_elevator_2" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elevator.sdf" />
 
   <node pkg="gazebo_ros" type="spawn_model" name="gazebo_elevator2" args="-sdf -param spawn_elevator_2 -model elevator_2 -x 9.356054 -y 12.938729 -z 0.3" respawn="false" output="screen">
   </node>

--- a/launch/elevator_doors.launch
+++ b/launch/elevator_doors.launch
@@ -3,49 +3,49 @@
 
 <!-- Load Param -->
 
-  <param name="spawn_auto_door_5" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" /> 
+  <param name="spawn_auto_door_5" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" />
 
-  <param name="spawn_auto_door_6" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" /> 
+  <param name="spawn_auto_door_6" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" />
 
-  <param name="spawn_auto_door_7" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" /> 
+  <param name="spawn_auto_door_7" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" />
 
-  <param name="spawn_auto_door_8" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" /> 
+  <param name="spawn_auto_door_8" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" />
 
-  <param name="spawn_auto_door_9" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" /> 
+  <param name="spawn_auto_door_9" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" />
 
-  <param name="spawn_auto_door_10" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" /> 
+  <param name="spawn_auto_door_10" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" />
 
-  <param name="spawn_auto_door_11" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" /> 
+  <param name="spawn_auto_door_11" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" />
 
-  <param name="spawn_auto_door_12" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" /> 
+  <param name="spawn_auto_door_12" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" />
 
-  <param name="spawn_auto_door_13" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" /> 
+  <param name="spawn_auto_door_13" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" />
 
-  <param name="spawn_auto_door_14" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" /> 
+  <param name="spawn_auto_door_14" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" />
 
-  <param name="spawn_auto_door_15" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" /> 
+  <param name="spawn_auto_door_15" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" />
 
-  <param name="spawn_auto_door_16" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" /> 
+  <param name="spawn_auto_door_16" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" />
 
-  <param name="spawn_auto_door_17" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" /> 
+  <param name="spawn_auto_door_17" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" />
 
-  <param name="spawn_auto_door_18" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" /> 
+  <param name="spawn_auto_door_18" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" />
 
-  <param name="spawn_auto_door_19" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" /> 
+  <param name="spawn_auto_door_19" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" />
 
-  <param name="spawn_auto_door_20" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" /> 
+  <param name="spawn_auto_door_20" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" />
 
-  <param name="spawn_auto_door_21" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" /> 
+  <param name="spawn_auto_door_21" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" />
 
-  <param name="spawn_auto_door_22" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" /> 
+  <param name="spawn_auto_door_22" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" />
 
-  <param name="spawn_auto_door_23" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" /> 
+  <param name="spawn_auto_door_23" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" />
 
-  <param name="spawn_auto_door_24" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" /> 
+  <param name="spawn_auto_door_24" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" />
 
-  <param name="spawn_auto_door_25" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" /> 
+  <param name="spawn_auto_door_25" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_left.sdf" />
 
-  <param name="spawn_auto_door_26" command="$(find xacro)/xacro.py $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" /> 
+  <param name="spawn_auto_door_26" command="$(find xacro)/xacro $(find dynamic_gazebo_models)/models/elev_slide_right.sdf" />
 
 
 <!-- Spawn -->


### PR DESCRIPTION
The xacro.py script has been deprecated for 5 years and has now been removed in xacro 1.14.4.